### PR TITLE
PE-7657: Proposal Limits and Revocations

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,18 @@
 
 ![image](https://github.com/user-attachments/assets/f89c8c96-911c-4cfc-8ba9-f63502690553)
 
-Propse and vAOt to:
+Propose and vAOt to:
 
 - add other wallet addresses, known as Controllers, that will have the right to propose votes and vote on proposals
 - remove existing controllers
-- have the process send an `Eval` message to another AO process (think: multi-sig-like, remote process control)
+- have the process send an `Eval` message to another AO process (think: multi-sig-like, remote process control) or to itself (e.g. for controllers-sanctioned upgrades or customization of the process)
+
+Suggested workflow for controlling processes with multi-sig-like protections:
+
+1. Instantiate a vAOt process. The initial `Owner` of the vAOt process will be the process creator.
+2. Assign ownership of the vAOt process to either: a) the process itself if you want Controllers to manage upgrades or Ownership or state changes of the vAOt process or b) nil if you want the vAOt process to remain unowned
+3. Add other Controllers via proposal and voting workflows.
+4. Assign the `Owner` of a target process that you'd like to manage via vAOt to the vAOt process. The Controllers can now collectively manage the target process via proposal and voting workflows.
 
 ## Handlers
 
@@ -23,7 +30,7 @@ Required:
 }
 ```
 
-Required for Add/Remove-Controller Proposal-Type:
+Required for Add/Remove-Controller `Proposal-Type`:
 
 ```json
 {
@@ -31,16 +38,23 @@ Required for Add/Remove-Controller Proposal-Type:
 }
 ```
 
-Required for Eval Proposal Type:
+Required for Eval `Proposal-Type`:
+
+Tags:
 
 ```json
 {
-  "Process-Id": "<AO Process ID to target for Eval>",
-  "Data": "<Eval string to send to target Process-Id>"
+  "Process-Id": "<AO Process ID to target for Eval>"
 }
 ```
 
-Optional for all Proposal-Types:
+Data:
+
+```text
+<Eval string to send to target Process-Id>
+```
+
+Optional for all `Proposal-Type`s:
 
 ```json
 {
@@ -57,6 +71,8 @@ Any current Controller can cast a vote on an In-Progress Proposal. Proposals are
 
 If the deciding vote Passes the proposal, the proposal is immediately implemented.
 
+If the outcome of a proposal is to remove a Controller, that Controller's existing votes on In-Progress proposals are revoked. In-Progress proposals are then re-evaluated for quorum immediately and may or may not reach a passable or failed outcome at that time. Proposal re-evaluation is handled in `Proposal-Number` order, i.e. the order in which proposals were created.
+
 Required:
 
 ```json
@@ -64,6 +80,19 @@ Required:
   "Action": "Vote",
   "Proposal-Id": "<Proposal ID string>"
   "Vote": "yay" or "nay"
+}
+```
+
+### Action: Revoke-Proposal
+
+Allows the Controller that proposed a proposal to revoke it before it is finalized.
+
+Required:
+
+```json
+{
+  "Action": "Revoke-Proposal",
+  "Proposal-Number": "<Proposal-Number string>"
 }
 ```
 

--- a/process/src/main.lua
+++ b/process/src/main.lua
@@ -416,11 +416,14 @@ addEventingHandler("propose", Handlers.utils.hasMatchingTag("Action", "Propose")
 	--- @diagnostic disable-next-line: inject-field
 	returnData.proposalName = proposalName
 
-	Send(msg, {
-		Target = msg.From,
-		Action = "Propose-" .. msg.Tags["Proposal-Type"] .. "-Notice",
-		Data = returnData,
-	})
+	-- Notify all the controllers that a proposal has been proposed
+	for controller, _ in pairs(Controllers) do
+		Send(msg, {
+			Target = controller,
+			Action = "Propose-" .. msg.Tags["Proposal-Type"] .. "-Notice",
+			Data = returnData,
+		})
+	end
 
 	handleMaybeVoteQuorum(proposalName, msg)
 end)

--- a/process/tests/integration.test.mjs
+++ b/process/tests/integration.test.mjs
@@ -122,6 +122,7 @@ describe('AOS Handlers:', () => {
               nays: [],
               controller,
               type: proposalType,
+              proposer: PROCESS_OWNER,
             },
             false,
           );
@@ -149,6 +150,7 @@ describe('AOS Handlers:', () => {
               nays: [],
               controller,
               type: proposalType,
+              proposer: PROCESS_OWNER,
             }
           );
     
@@ -184,6 +186,7 @@ describe('AOS Handlers:', () => {
               },
               controller,
               type: proposalType,
+              proposer: PROCESS_OWNER,
             }
           );
     
@@ -367,6 +370,7 @@ describe('AOS Handlers:', () => {
             nays: [],
             controller: 'new-controller',
             type: "Add-Controller",
+            proposer: PROCESS_OWNER,
           });
     
           // Ensure that the vote is now over
@@ -399,6 +403,7 @@ describe('AOS Handlers:', () => {
             },
             controller: 'new-controller',
             type: "Add-Controller",
+            proposer: PROCESS_OWNER,
           });
     
           // Ensure that the vote is now over
@@ -459,6 +464,7 @@ describe('AOS Handlers:', () => {
               nays: [],
               controller: 'new-controller2',
               type: "Add-Controller",
+              proposer: PROCESS_OWNER,
             });
           });
 
@@ -482,6 +488,7 @@ describe('AOS Handlers:', () => {
               },
               controller: 'new-controller2',
               type: "Add-Controller",
+              proposer: PROCESS_OWNER,
             });
           });
 
@@ -522,6 +529,7 @@ describe('AOS Handlers:', () => {
               },
               controller: 'new-controller2',
               type: "Add-Controller",
+              proposer: PROCESS_OWNER,
             });
 
             // Assert that the proposal is in memory
@@ -536,6 +544,7 @@ describe('AOS Handlers:', () => {
                 },
                 controller: 'new-controller2',
                 type: "Add-Controller",
+                proposer: PROCESS_OWNER,
               },
             });
 
@@ -559,6 +568,7 @@ describe('AOS Handlers:', () => {
                 nays: [],
                 controller: 'new-controller2',
                 type: "Add-Controller",
+                proposer: PROCESS_OWNER,
               },
             });
           });
@@ -658,6 +668,7 @@ describe('AOS Handlers:', () => {
                 },
                 controller: 'new-controller2',
                 type: "Add-Controller",  
+                proposer: PROCESS_OWNER,
               }
             })
 
@@ -829,6 +840,7 @@ describe('AOS Handlers:', () => {
                 nays: [],
                 controller: 'new-controller2',
                 type: "Add-Controller",
+                proposer: PROCESS_OWNER,
               },
             });
 
@@ -963,6 +975,7 @@ describe('AOS Handlers:', () => {
             nays: [],
             controller: 'new-controller2',
             type: "Add-Controller",
+            proposer: PROCESS_OWNER,
           });
     
           // Ensure the proposal is now completed
@@ -996,6 +1009,7 @@ describe('AOS Handlers:', () => {
             },
             controller: 'new-controller2',
             type: "Add-Controller",
+            proposer: PROCESS_OWNER,
           });
     
           // Ensure the proposal is now completed
@@ -1136,6 +1150,39 @@ describe('AOS Handlers:', () => {
         assert.deepEqual(evalMessage.Data, 'print("Hello, World!")');
         // TODO: More thorough testing here
       });
+    });
+
+    it('should not allow a controller to exceed the maximum number of proposals', async () => {
+      const proposals = await getProposals(testMemory);
+      let memory = testMemory;
+      for (let i = Object.keys(proposals).length; i < 10; i++) {
+        const result = await handle({
+          options: {
+            Tags: [
+              { name: 'Action', value: 'Propose' },
+              { name: 'Proposal-Type', value: 'Add-Controller' },
+              { name: 'Controller', value: `new-controller-${i}` },
+            ],
+          },
+          mem: memory,
+        });
+        assert.deepEqual(result.Error, undefined);
+        memory = result.Memory;
+      }
+
+      assert.deepEqual(Object.keys(await getProposals(memory)).length, 10);
+
+      const result = await handle({
+        options: {
+          Tags: [
+            { name: 'Action', value: 'Propose' },
+            { name: 'Proposal-Type', value: 'Add-Controller' },
+            { name: 'Controller', value: 'new-controller-10' },
+          ],
+        },
+        mem: memory,
+      });
+      assert(result.Messages[0].Data?.includes("Controller has the maximum number of proposals (10) active"));
     });
   });
 });


### PR DESCRIPTION
- Limit controllers to 10 in-flight proposals at a time to prevent any specific one from bricking the process with spurious proposals. The limit can be modified if the process owns itself and an eval proposal is made to change the global constant (in theory).
- All proposers of proposals to revoke their proposal unilaterally at any time that they are still (or reinstated as) a controller
- Broadcast new proposals to all controllers